### PR TITLE
feat: add support for additional nixos-rebuild options, refactor and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# 🍦 Nilla NixOS
+
+> Work with NixOS systems in [Nilla](https://github.com/nilla-nix/nilla) projects with ease.
+
+## Integration with Nilla CLI
+
+Nilla NixOS integrates with the [Nilla CLI](https://github.com/nilla-nix/cli) through its external subcommand mechanism. When you run `nilla os`, the Nilla CLI looks for a binary named `nilla-os` in your PATH and executes it with the remaining arguments.
+
+### How It Works
+
+The Nilla CLI supports external subcommands via the `external_subcommand` mechanism. When you run `nilla <subcommand>`, it searches for a binary named `nilla-<subcommand>` in your PATH. Once `nilla-nixos` is installed (using one of the methods below), it will be available as `nilla-os` and can be used via the Nilla CLI.
+
+### Commands
+
+Once installed, you can use it via the Nilla CLI:
+
+```bash
+# Build a NixOS system
+nilla nixos build <system_name>
+
+# Build and switch to a configuration
+nilla nixos switch <system_name>
+
+# Test a configuration (activate without making it boot default)
+nilla nixos test <system_name>
+
+# Pass additional nixos-rebuild options
+nilla nixos switch <system_name> -- --target-host user@remote
+nilla nixos build <system_name> -- --build-host user@builder
+```
+
+## Install with Nilla
+
+You can add Nilla NixOS to your Nilla project and access using the following code:
+
+```nix
+# In any module of your project.
+{ config }:
+let
+    nilla-nixos-package = config.inputs.nilla-nixos.packages.nilla-nixos.x86_64-linux;
+in
+{
+    config = {
+        inputs.nilla-nixos.src = builtins.fetchTarball {
+            url = "https://github.com/nilla-nix/nixos/archive/main.tar.gz";
+            sha256 = "0000000000000000000000000000000000000000000000000000";
+        };
+
+        # Do something with the package.
+    };
+}
+```
+
+## Install without Flakes
+
+You can install Nilla NixOS in your NixOS, home-manager, or nix-darwin configuration.
+
+```nix
+# configuration.nix
+{ pkgs, ... }:
+let
+  nilla-nixos = import (builtins.fetchTarball {
+    url = "https://github.com/nilla-nix/nixos/archive/main.tar.gz";
+    sha256 = "0000000000000000000000000000000000000000000000000000";
+  });
+  nilla-nixos-package = nilla-nixos.packages.nilla-nixos.result.${pkgs.system};
+in
+{
+  environment.systemPackages = [
+    nilla-nixos-package
+  ];
+}
+```
+
+## Install with Flakes
+
+You can add Nilla NixOS as a Flake input.
+
+```nix
+# flake.nix
+{
+  inputs = {
+    nilla-nixos.url = "github:nilla-nix/nixos";
+  };
+
+  outputs = { nilla-nixos, ... }:
+    let
+      nilla-nixos-package = nilla-nixos.packages.x86_64-linux.nilla-nixos;
+    in
+      # Do something with the package.
+      {};
+}
+```
+
+## Run with Flakes
+
+You can run Nilla NixOS directly via Flakes.
+
+```bash
+# Place any arguments you want to provide to Nilla NixOS after the --
+nix run github:nilla-nix/nixos -- --help
+```

--- a/nixos-cli-def/src/commands/build.rs
+++ b/nixos-cli-def/src/commands/build.rs
@@ -1,9 +1,14 @@
 use clap::Args;
 #[derive(Debug, Args)]
-#[command(about = "Build a NixOS system")]
+#[command(
+    about = "Build a NixOS system",
+    long_about = "Build a NixOS system. Additional nixos-rebuild options can be passed after --, e.g.: nilla nixos build -- --build-host user@remote --target-host user@target"
+)]
 pub struct BuildArgs {
     #[arg(help = "System name")]
     pub name: Option<String>,
     #[arg(short, long, help = "System architecture (eg: x86_64-linux)")]
     pub system: Option<String>,
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, help = "Additional arguments to pass to nixos-rebuild")]
+    pub extra_nixos_rebuild_args: Vec<String>,
 }

--- a/nixos-cli-def/src/commands/switch.rs
+++ b/nixos-cli-def/src/commands/switch.rs
@@ -1,10 +1,15 @@
 use clap::Args;
 
 #[derive(Debug, Args)]
-#[command(about = "Build, install, and switch into a system")]
+#[command(
+    about = "Build, install, and switch into a system",
+    long_about = "Build, install, and switch into a system. Additional nixos-rebuild options can be passed after --, e.g.: nilla nixos switch -- --build-host user@remote --target-host user@target"
+)]
 pub struct SwitchArgs {
     #[arg(help = "System name")]
     pub name: Option<String>,
     #[arg(short, long, help = "System architecture (eg: x86_64-linux)")]
     pub system: Option<String>,
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, help = "Additional arguments to pass to nixos-rebuild")]
+    pub extra_nixos_rebuild_args: Vec<String>,
 }

--- a/nixos-cli-def/src/commands/test.rs
+++ b/nixos-cli-def/src/commands/test.rs
@@ -1,10 +1,15 @@
 use clap::Args;
 
 #[derive(Debug, Args)]
-#[command(about = "Test a system")]
+#[command(
+    about = "Test a system",
+    long_about = "Test a system. Additional nixos-rebuild options can be passed after --, e.g.: nilla nixos test -- --build-host user@remote --target-host user@target"
+)]
 pub struct TestArgs {
     #[arg(help = "System name")]
     pub name: Option<String>,
     #[arg(short, long, help = "System architecture (eg: x86_64-linux)")]
     pub system: Option<String>,
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, help = "Additional arguments to pass to nixos-rebuild")]
+    pub extra_nixos_rebuild_args: Vec<String>,
 }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,43 +1,33 @@
-use log::{debug, error, info};
-use tokio::process::Command;
+use log::error;
+
+use crate::commands::common;
 
 pub async fn build_cmd(cli: &nixos_cli_def::Cli, args: &nixos_cli_def::commands::build::BuildArgs) {
-    debug!("Resolving project {}", cli.project);
-    let Ok(project) = crate::util::project::resolve(&cli.project).await else {
-        return error!("Could not find project {}", cli.project);
+    let path = match common::get_nilla_nix_path(&cli.project).await {
+        Ok(p) => p,
+        Err(e) => return error!("{}", e),
     };
 
-    let mut path = project.get_path();
-
-    debug!("Resolved project {path:?}");
-
-    path.push("nilla.nix");
-
-    match path.try_exists() {
-        Ok(false) | Err(_) => return error!("File not found"),
-        _ => {}
-    }
-
-    let hostname = if let Some(name) = args.name.clone() {
-        if name.contains('.') {
-            return error!("Invalid hostname {}", name);
-        } else {
-            name
-        }
-    } else {
-        gethostname::gethostname().into_string().unwrap()
+    let hostname = match common::get_hostname(args.name.clone()) {
+        Ok(h) => h,
+        Err(e) => return error!("{}", e),
     };
 
-    let attribute = &format!("systems.nixos.\"{hostname}\".result");
+    let attribute = common::format_attribute(&hostname);
+    let (build_host, _) = crate::util::args::extract_hosts_from_args(&args.extra_nixos_rebuild_args);
 
-    info!("Building system {hostname}");
-    Command::new("nixos-rebuild")
-        .arg("build")
-        .arg("--file")
-        .arg(path.display().to_string())
-        .arg("--attr")
-        .arg(attribute)
-        .status()
-        .await
-        .unwrap();
+    common::log_build_operation(&hostname, build_host.as_ref());
+
+    let mut cmd = match common::build_nixos_rebuild_command(
+        "build",
+        &path,
+        &attribute,
+        &args.extra_nixos_rebuild_args,
+        false, // build command never needs sudo
+    ) {
+        Ok(c) => c,
+        Err(e) => return error!("{}", e),
+    };
+
+    cmd.status().await.unwrap();
 }

--- a/src/commands/common.rs
+++ b/src/commands/common.rs
@@ -1,0 +1,113 @@
+use log::{debug, error, info};
+use std::path::PathBuf;
+use tokio::process::Command;
+
+/// Common arguments trait for commands that support nixos-rebuild passthrough
+pub trait NixosRebuildArgs {
+    fn name(&self) -> Option<String>;
+    fn extra_nixos_rebuild_args(&self) -> &[String];
+}
+
+/// Get the path to nilla.nix file from the project
+pub async fn get_nilla_nix_path(project: &str) -> Result<PathBuf, String> {
+    debug!("Resolving project {}", project);
+    let project = crate::util::project::resolve(project)
+        .await
+        .map_err(|_| format!("Could not find project {}", project))?;
+
+    let mut path = project.get_path();
+    debug!("Resolved project {path:?}");
+
+    path.push("nilla.nix");
+
+    match path.try_exists() {
+        Ok(false) | Err(_) => Err("File not found".to_string()),
+        _ => Ok(path),
+    }
+}
+
+/// Get and validate hostname from args or system
+pub fn get_hostname(name: Option<String>) -> Result<String, String> {
+    if let Some(name) = name {
+        if name.contains('.') {
+            return Err(format!("Invalid hostname {}", name));
+        }
+        Ok(name)
+    } else {
+        Ok(gethostname::gethostname().into_string().unwrap())
+    }
+}
+
+/// Format the NixOS attribute path for a hostname
+pub fn format_attribute(hostname: &str) -> String {
+    format!("systems.nixos.\"{hostname}\".result")
+}
+
+/// Get sudo/doas command path
+fn get_sudo_command() -> Result<std::path::PathBuf, String> {
+    which::which("sudo")
+        .or_else(|_| which::which("doas"))
+        .map_err(|_| "Could not find sudo or doas".to_string())
+}
+
+/// Build the nixos-rebuild command with proper sudo handling
+pub fn build_nixos_rebuild_command(
+    subcommand: &str,
+    path: &PathBuf,
+    attribute: &str,
+    extra_args: &[String],
+    needs_sudo: bool,
+) -> Result<Command, String> {
+    let mut cmd = if needs_sudo {
+        let sudo = get_sudo_command()?;
+        let mut sudo_cmd = Command::new(sudo);
+        sudo_cmd.arg("nixos-rebuild");
+        sudo_cmd
+    } else {
+        Command::new("nixos-rebuild")
+    };
+
+    cmd.arg(subcommand)
+        .arg("--file")
+        .arg(path.display().to_string())
+        .arg("--attr")
+        .arg(attribute);
+
+    for arg in extra_args {
+        cmd.arg(arg);
+    }
+
+    Ok(cmd)
+}
+
+/// Format location string for logging
+fn format_location(host: Option<&String>) -> &str {
+    host.map(|h| h.as_str()).unwrap_or("locally")
+}
+
+/// Log operation with location information
+pub fn log_operation(
+    action: &str,
+    hostname: &str,
+    build_host: Option<&String>,
+    target_host: Option<&String>,
+) {
+    let build_location = format_location(build_host);
+    let activate_location = format_location(target_host);
+
+    if build_host.is_some() || target_host.is_some() {
+        info!("{action} system {hostname} (build: {build_location}, activate: {activate_location})");
+    } else {
+        info!("{action} system {hostname} locally");
+    }
+}
+
+/// Log build operation (simpler version for build command)
+pub fn log_build_operation(hostname: &str, build_host: Option<&String>) {
+    let build_location = format_location(build_host);
+    if build_host.is_some() {
+        info!("Building system {hostname} on {build_location}");
+    } else {
+        info!("Building system {hostname} locally");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod build;
+pub mod common;
 pub mod switch;
 pub mod test;

--- a/src/commands/switch.rs
+++ b/src/commands/switch.rs
@@ -1,55 +1,40 @@
-use log::{debug, error, info};
-use tokio::process::Command;
+use log::error;
+
+use crate::commands::common;
 
 pub async fn switch_cmd(
     cli: &nixos_cli_def::Cli,
     args: &nixos_cli_def::commands::switch::SwitchArgs,
 ) {
-    debug!("Resolving project {}", cli.project);
-    let Ok(project) = crate::util::project::resolve(&cli.project).await else {
-        return error!("Could not find project {}", cli.project);
+    let path = match common::get_nilla_nix_path(&cli.project).await {
+        Ok(p) => p,
+        Err(e) => return error!("{}", e),
     };
 
-    let mut path = project.get_path();
-
-    debug!("Resolved project {path:?}");
-
-    path.push("nilla.nix");
-
-    match path.try_exists() {
-        Ok(false) | Err(_) => return error!("File not found"),
-        _ => {}
-    }
-
-    let hostname = if let Some(name) = args.name.clone() {
-        if name.contains('.') {
-            return error!("Invalid hostname {}", name);
-        } else {
-            name
-        }
-    } else {
-        gethostname::gethostname().into_string().unwrap()
+    let hostname = match common::get_hostname(args.name.clone()) {
+        Ok(h) => h,
+        Err(e) => return error!("{}", e),
     };
 
-    let attribute = &format!("systems.nixos.\"{hostname}\".result");
+    let attribute = common::format_attribute(&hostname);
+    let (build_host, target_host) =
+        crate::util::args::extract_hosts_from_args(&args.extra_nixos_rebuild_args);
 
-    let sudo = match which::which("sudo") {
-        Ok(s) => s,
-        Err(_e) => match which::which("doas") {
-            Ok(d) => d,
-            Err(_e) => return error!("Could not find sudo or doas"),
-        },
+    // Don't use sudo locally if --target-host is specified (activation happens remotely)
+    let needs_sudo = target_host.is_none();
+
+    common::log_operation("Switching", &hostname, build_host.as_ref(), target_host.as_ref());
+
+    let mut cmd = match common::build_nixos_rebuild_command(
+        "switch",
+        &path,
+        &attribute,
+        &args.extra_nixos_rebuild_args,
+        needs_sudo,
+    ) {
+        Ok(c) => c,
+        Err(e) => return error!("{}", e),
     };
 
-    info!("Switching system {hostname}");
-    Command::new(sudo)
-        .arg("nixos-rebuild")
-        .arg("switch")
-        .arg("--file")
-        .arg(path.display().to_string())
-        .arg("--attr")
-        .arg(attribute)
-        .status()
-        .await
-        .unwrap();
+    cmd.status().await.unwrap();
 }

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -1,52 +1,37 @@
-use log::{debug, error, info};
-use tokio::process::Command;
+use log::error;
+
+use crate::commands::common;
 
 pub async fn test_cmd(cli: &nixos_cli_def::Cli, args: &nixos_cli_def::commands::test::TestArgs) {
-    debug!("Resolving project {}", cli.project);
-    let Ok(project) = crate::util::project::resolve(&cli.project).await else {
-        return error!("Could not find project {}", cli.project);
+    let path = match common::get_nilla_nix_path(&cli.project).await {
+        Ok(p) => p,
+        Err(e) => return error!("{}", e),
     };
 
-    let mut path = project.get_path();
-
-    debug!("Resolved project {path:?}");
-
-    path.push("nilla.nix");
-
-    match path.try_exists() {
-        Ok(false) | Err(_) => return error!("File not found"),
-        _ => {}
-    }
-
-    let hostname = if let Some(name) = args.name.clone() {
-        if name.contains('.') {
-            return error!("Invalid hostname {}", name);
-        } else {
-            name
-        }
-    } else {
-        gethostname::gethostname().into_string().unwrap()
+    let hostname = match common::get_hostname(args.name.clone()) {
+        Ok(h) => h,
+        Err(e) => return error!("{}", e),
     };
 
-    let attribute = &format!("systems.nixos.\"{hostname}\".result");
+    let attribute = common::format_attribute(&hostname);
+    let (build_host, target_host) =
+        crate::util::args::extract_hosts_from_args(&args.extra_nixos_rebuild_args);
 
-    let sudo = match which::which("sudo") {
-        Ok(s) => s,
-        Err(_e) => match which::which("doas") {
-            Ok(d) => d,
-            Err(_e) => return error!("Could not find sudo or doas"),
-        },
+    // Don't use sudo locally if --target-host is specified (activation happens remotely)
+    let needs_sudo = target_host.is_none();
+
+    common::log_operation("Testing", &hostname, build_host.as_ref(), target_host.as_ref());
+
+    let mut cmd = match common::build_nixos_rebuild_command(
+        "test",
+        &path,
+        &attribute,
+        &args.extra_nixos_rebuild_args,
+        needs_sudo,
+    ) {
+        Ok(c) => c,
+        Err(e) => return error!("{}", e),
     };
 
-    info!("Testing system {hostname}");
-    Command::new(sudo)
-        .arg("nixos-rebuild")
-        .arg("test")
-        .arg("--file")
-        .arg(path.display().to_string())
-        .arg("--attr")
-        .arg(attribute)
-        .status()
-        .await
-        .unwrap();
+    cmd.status().await.unwrap();
 }

--- a/src/util/args.rs
+++ b/src/util/args.rs
@@ -1,0 +1,33 @@
+/// nixos-rebuild flag for specifying a remote build host
+pub const BUILD_HOST_FLAG: &str = "--build-host";
+
+/// nixos-rebuild flag for specifying a remote target host
+pub const TARGET_HOST_FLAG: &str = "--target-host";
+
+/// Extract a host value from command-line arguments for a given flag.
+///
+/// Supports both `--flag value` and `--flag=value` formats.
+pub fn extract_host_from_args(args: &[String], flag: &str) -> Option<String> {
+    for (i, arg) in args.iter().enumerate() {
+        if arg == flag {
+            // Check if next argument is the host value
+            if let Some(next) = args.get(i + 1) {
+                if !next.starts_with('-') {
+                    return Some(next.clone());
+                }
+            }
+        } else if arg.starts_with(&format!("{}=", flag)) {
+            // Handle --flag=value format
+            return arg.split('=').nth(1).map(|s| s.to_string());
+        }
+    }
+    None
+}
+
+/// Extract both build and target host information from arguments.
+pub fn extract_hosts_from_args(args: &[String]) -> (Option<String>, Option<String>) {
+    (
+        extract_host_from_args(args, BUILD_HOST_FLAG),
+        extract_host_from_args(args, TARGET_HOST_FLAG),
+    )
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod args;
 pub mod errors;
 pub mod git;
 pub mod nix;


### PR DESCRIPTION
This PR adds support for passing additional `nixos-rebuild` options to enable e.g. remote builds and remote targets in `nilla-nixos`, along with comprehensive code refactoring to improve maintainability and reduce duplication. It also adds an initial `README.md`.

## Features

### Passing additional nixos-rebuild option to enable Remote Build and Target Support

- Support for passing additional `nixos-rebuild` options via `--` separator
- Enables remote builds using `--build-host` and remote activation using `--target-host`
- Automatic detection of remote operations to skip local sudo when appropriate
- Informative logging indicating where build/test/switch operations occur (locally or remotely)

```bash
# Build on a remote host
nilla nixos build <system_name> -- --build-host user@builder -S

# Build and switch on a remote target
nilla nixos switch <system_name> -- --target-host user@remote -S

# Combine both for cross-compilation scenarios
nilla nixos build <system_name> -- --build-host user@builder --target-host user@target -S
```

### Improved Logging

- Clear indication of operation location (local vs remote)
- Build operations show where the build happens
- Switch/test operations show both build and target locations

```
🍦 Nilla  INFO  Building '<system_name>' locally...
🍦 Nilla  INFO  Switching system <system_name> locally
🍦 Nilla  INFO  Building '<system_name>' on user@remote...
🍦 Nilla  INFO  Switching '<system_name>' (build: user@builder, target: user@remote)...
```

## Code Improvements

### Refactoring

- Extracted common `nixos-rebuild` logic into a shared `commands/common.rs` module
- Created `util/args.rs` module with constants and utilities for argument parsing
- Reduced code duplication across `build`, `switch`, and `test` commands
- Centralized project resolution, hostname handling, and command building logic

### Technical Details

- Uses Clap's `trailing_var_arg` and `allow_hyphen_values` for flexible argument passthrough
- Conditional sudo/doas usage based on operation type and target location
- Constants for `--build-host` and `--target-host` flags to reduce duplication
- Utility functions for extracting host information from command-line arguments

## Documentation

- Added comprehensive `README.md` with installation instructions
- Documents integration with `nilla-cli` as an external subcommand
- Includes usage examples for remote builds and targets
- Covers installation methods: with Nilla, without Flakes, with Flakes, and run with Flakes
