### PR TITLE
fix: allow pure evaluation

### DIFF
--- a/modules/nixos.nix
+++ b/modules/nixos.nix
@@ -39,6 +39,7 @@ in
             type = lib.types.raw;
             writable = false;
             default.value = import "${config.pkgs.path}/nixos/lib/eval-config.nix" {
+              system = null;
               pkgs = config.pkgs;
               lib = config.pkgs.lib;
               specialArgs = config.args;


### PR DESCRIPTION
afaik setting the `eval-config.nix` `system` to `null` unconditionally should be fine given pre-selected `pkgs` is being supplied (and barring that `hardware-config.nix` generation has set the system option explicitly for a while).

Evaluating nilla purely also requires `builtins.storePath`, which (at least for lix) is currently only pure on main.